### PR TITLE
Retitle README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ecs_prometheus_exporter
+# ecs_exporter
 
 🚧 🚧 🚧 This repo is still work in progress and is subject to change.
 


### PR DESCRIPTION
The old title is carried over from the old repo. Renaming
the title to match the new repo name.

Signed-off-by: JBD <jbd@amazon.com>