### PR TITLE
Make metadata client useful outside of ECS

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func main() {
 	flag.StringVar(&addr, "addr", ":9779", "The address to listen on for HTTP requests.")
 	flag.Parse()
 
-	client, err := ecsmetadata.NewClient(nil)
+	client, err := ecsmetadata.NewClient("", nil)
 	if err != nil {
 		log.Fatalf("Error creating client: %v", err)
 	}


### PR DESCRIPTION
Allow users to create a client without having to rely on the metadata server's environmental variable.

Signed-off-by: JBD <jbd@amazon.com>