### PR TITLE
Allow ecsmetadata to work outside of ECS

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func main() {
 	flag.StringVar(&addr, "addr", ":9779", "The address to listen on for HTTP requests.")
 	flag.Parse()
 
-	client, err := ecsmetadata.NewClient(nil)
+	client, err := ecsmetadata.NewClientFromEnvironment()
 	if err != nil {
 		log.Fatalf("Error creating client: %v", err)
 	}


### PR DESCRIPTION
Provide a constructor, NewClientFromEnvironment to automatically
discover the metadata service to create a client. Allow users to
create a client with any metadata server endpoint.

Additionally, export the HTTP client in ecsmetadata.Client for
users to be able to set custom HTTP clients before using the
metadata client.

Fixes #17.