### PR TITLE
Improve logging

### DIFF
--- a/ecscollector/collector.go
+++ b/ecscollector/collector.go
@@ -170,6 +170,7 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 		c.logger.Debug("Failed to retrieve metadata", "error", err)
 		return
 	}
+	c.logger.Debug("Got ECS task metadata response", "stats", metadata)
 
 	ch <- prometheus.MustNewConstMetric(
 		metadataDesc,
@@ -213,6 +214,8 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 		c.logger.Debug("Failed to retrieve container stats", "error", err)
 		return
 	}
+	c.logger.Debug("Got ECS task stats response", "stats", stats)
+
 	for _, container := range metadata.Containers {
 		s := stats[container.ID]
 		if s == nil {

--- a/ecsmetadata/client.go
+++ b/ecsmetadata/client.go
@@ -49,11 +49,11 @@ func NewClientFromEnvironment() (*Client, error) {
 	const endpointEnv = "ECS_CONTAINER_METADATA_URI_V4"
 	endpoint := os.Getenv(endpointEnv)
 	if endpoint == "" {
-		return nil, fmt.Errorf("%q environmental variable is not set; not running on ECS", endpointEnv)
+		return nil, fmt.Errorf("%s is not set; not running on ECS?", endpointEnv)
 	}
 	_, err := url.Parse(endpoint)
 	if err != nil {
-		return nil, fmt.Errorf("can't parse %q as URL: %w", endpointEnv, err)
+		return nil, fmt.Errorf("can't parse %s as URL: %w", endpointEnv, err)
 	}
 	return NewClient(endpoint), nil
 }
@@ -98,5 +98,10 @@ func (c *Client) request(ctx context.Context, uri string, out interface{}) error
 	if err != nil {
 		return err
 	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("%q: %s %s: %q", uri, resp.Proto, resp.Status, string(body)[:100])
+	}
+
 	return json.Unmarshal(body, out)
 }


### PR DESCRIPTION
- Add debug logging that logs the full ECS responses, which can be used with JSON log formatting to enable developing against the actual behavior of the ECS APIs.
- Error when the ECS APIs return a non-2xx response. They are not specified to ever do so, but surely we should not be trying to deserialize response bodies to the usual JSON objects in such situations.